### PR TITLE
Verify PDF/A in GitHub workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,3 +32,24 @@ jobs:
           path: |
             *.pdf
 
+  verify:
+    name: Verify PDF/A
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Checkout verifier
+        uses: actions/checkout@v2
+        with:
+          repository: mff-cuni-cz/cuni-thesis-validator
+          ref: ba1d9e7be0b70782bf19643eb9a7627ec046dfb7
+      - name: Build verifier Docker image
+        run: docker build -t thesis-validator .
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: Thesis
+      - name: Run verifier
+        run: >
+          docker run --rm -i -v $PWD:/thesis thesis-validator verify
+          /thesis/*.pdf | tee /dev/stderr | grep -qE 'nonCompliant="0"'


### PR DESCRIPTION
I've added a step to GitHub CI that automatically verifies PDF/A using the [CUNI validator](https://github.com/mff-cuni-cz/cuni-thesis-validator). I'm not familiar with GitLab CI, so that's not included.