### PR TITLE
Use Czech babel in abstract

### DIFF
--- a/abstract-cz.tex
+++ b/abstract-cz.tex
@@ -1,6 +1,7 @@
 \documentclass[12pt]{report}
 
 \usepackage[a-2u]{pdfx}
+\usepackage[czech,shorthands=off]{babel}
 \usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}
 


### PR DESCRIPTION
Without this, I got weirdly split words in my Czech abstract (e.g., `ne-jlepší`).