### PR TITLE
Remove page numbers from abstract PDFs

### DIFF
--- a/abstract-cz.tex
+++ b/abstract-cz.tex
@@ -10,5 +10,6 @@
 \input{todos}
 
 \begin{document}
+\thispagestyle{empty}
 \AbstractCS
 \end{document}

--- a/abstract-cz.tex
+++ b/abstract-cz.tex
@@ -10,6 +10,6 @@
 \input{todos}
 
 \begin{document}
-\thispagestyle{empty}
+\pagenumbering{gobble}
 \AbstractCS
 \end{document}

--- a/abstract-en.tex
+++ b/abstract-en.tex
@@ -10,6 +10,6 @@
 \input{todos}
 
 \begin{document}
-\thispagestyle{empty}
+\pagenumbering{gobble}
 \AbstractEN
 \end{document}

--- a/abstract-en.tex
+++ b/abstract-en.tex
@@ -10,5 +10,6 @@
 \input{todos}
 
 \begin{document}
+\thispagestyle{empty}
 \AbstractEN
 \end{document}


### PR DESCRIPTION
I believe page numbers in the generated abstract PDFs are erroneously preserved in the [Digital Repository](https://dspace.cuni.cz/handle/20.500.11956/106081), like this (see the `1` at the end):

![image](https://user-images.githubusercontent.com/3669664/167289885-8ea639ca-24c3-4d63-8aab-ada5e3780a14.png)
