### PR TITLE
use the prebuilt containers for CI PDF/A verification

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,27 +1,20 @@
 name: CI
 
-# Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: [ master ]
   pull_request:
     branches: [ master ]
 
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
+    name: Build thesis PDFs
     runs-on: ubuntu-latest
     container: { image: 'aergus/latex' }
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
       - name: Build the thesis
         run: latexmk thesis && latexmk abstract-cz && latexmk abstract-en
@@ -36,20 +29,9 @@ jobs:
     name: Verify PDF/A
     runs-on: ubuntu-latest
     needs: build
+    container: { image: 'ghcr.io/mff-cuni-cz/cuni-thesis-validator' }
 
     steps:
-      - name: Checkout verifier
-        uses: actions/checkout@v2
-        with:
-          repository: mff-cuni-cz/cuni-thesis-validator
-          ref: ba1d9e7be0b70782bf19643eb9a7627ec046dfb7
-      - name: Build verifier Docker image
-        run: docker build -t thesis-validator .
-      - name: Download artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: Thesis
-      - name: Run verifier
+      - name: Run VeraPDF
         run: >
-          docker run --rm -i -v $PWD:/thesis thesis-validator verify
-          /thesis/*.pdf | tee /dev/stderr | grep -qE 'nonCompliant="0"'
+          verify *.pdf | tee /dev/stderr | grep -qE 'nonCompliant="0"'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,7 @@
 name: CI
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
 
   workflow_dispatch:
 
@@ -19,7 +16,7 @@ jobs:
       - name: Build the thesis
         run: latexmk thesis && latexmk abstract-cz && latexmk abstract-en
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Thesis
           path: |
@@ -32,6 +29,7 @@ jobs:
     container: { image: 'ghcr.io/mff-cuni-cz/cuni-thesis-validator' }
 
     steps:
+      - name: Get PDFs
+        uses: actions/download-artifact@v3
       - name: Run VeraPDF
-        run: >
-          verify *.pdf | tee /dev/stderr | grep -qE 'nonCompliant="0"'
+        run: verify Thesis/*.pdf | tee /dev/stderr | grep -qE 'nonCompliant="0"'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
     name: Verify PDF/A
     runs-on: ubuntu-latest
     needs: build
-    container: { image: 'ghcr.io/mff-cuni-cz/cuni-thesis-validator' }
+    container: { image: 'ghcr.io/exaexa/cuni-thesis-validator' }
 
     steps:
       - name: Get PDFs

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,12 +4,24 @@
 #
 # It works with the gitlab.mff.cuni.cz instance.
 #
-image: aergus/latex
 
-build:
-  script: latexmk thesis && latexmk abstract-cz && latexmk abstract-en;
+stages:
+  - build
+  - verify
+
+latexmk:
+  stage: build
+  image: aergus/latex
+  script: |
+    latexmk thesis && latexmk abstract-cz && latexmk abstract-en;
   artifacts:
     paths:
       - thesis.pdf
       - abstract-cz.pdf
       - abstract-en.pdf
+
+verapdf:
+  stage: verify
+  image: ghcr.io/mff-cuni-cz/cuni-thesis-validator
+  script: |
+    verify *.pdf |tee /dev/stderr |grep -qE 'nonCompliant="0"'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,6 @@ latexmk:
 
 verapdf:
   stage: verify
-  image: ghcr.io/mff-cuni-cz/cuni-thesis-validator
+  image: ghcr.io/exaexa/cuni-thesis-validator
   script: |
     verify *.pdf |tee /dev/stderr |grep -qE 'nonCompliant="0"'

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ docker run -u $UID -ti --rm -v $PWD:/th -w /th aergus/latex make
 
 ## PDF/A
 
-With a bit of luck, you should get a valid PDF/A right out of LaTeX.
+With a bit of luck, you should get a valid PDF/A right out of LaTeX. If you are using GitHub actions or GitLab CI, the CI will run the PDF/A verifier automatically for you.
 
 A PDF/A validator that can point out exact problems is available here: https://github.com/mff-cuni-cz/cuni-thesis-validator
 


### PR DESCRIPTION
Depends on https://github.com/mff-cuni-cz/cuni-thesis-validator/pull/2 . Enables running VeraPDF in gitlab and simplifies the github action a bit.

Tested here with a temporary fixup of the repo path (will fix later). Volunteers for testing in gitlab welcome.

(cc @jjonescz, suggestions welcome :D )