### PR TITLE
Suggest using luatex instead of pdflatex in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME=thesis
 ABSTRACT=abstract
-LATEXMKOPTS=#-pdf #enable for forcing pdflatex
+LATEXMKOPTS=#-pdflua #enable for forcing luatex
 LATEXMK=latexmk $(LATEXMKOPTS)
 
 all:


### PR DESCRIPTION
Using the suggested option `-pdf` to force pdflatex in the Makefile leads to PDF/A non-compliant results. Forcing luatex by using `-pdflua` works better.